### PR TITLE
Test jobs failing from deprecated setup action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -364,9 +364,9 @@ jobs:
           node-version: '14'
       - name: Install Playwright
         run: |
-            npx playwright install --with-deps
+            npx playwright install-deps
+            npx playwright install 
             dotnet build Framework/FrameworkUnitTests/FrameworkUnitTests.csproj -o Framework/FrameworkUnitTests/build
-            pwsh Framework/FrameworkUnitTests/build/playwright.ps1 install-deps
             pwsh Framework/FrameworkUnitTests/build/playwright.ps1 install  
       - run: dotnet restore Framework/FrameworkUnitTests/FrameworkUnitTests.csproj
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,6 +92,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: xt0rted/setup-dotnet@v1.0.0
+        with:
+          dotnet-version: |
+            3.1.417
+            6.0.201
+            7.0.203
       - id: builder
         env:
           GlobalMaqs:ConfigJsonEnvRunOverride: ENV
@@ -142,6 +149,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: xt0rted/setup-dotnet@v1.0.0
+        with:
+          dotnet-version: |
+            3.1.417
+            6.0.201
+            7.0.203
       - id: builder
         uses: ./.github/workflows/buildtest-action
         with:
@@ -161,6 +175,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: xt0rted/setup-dotnet@v1.0.0
+        with:
+          dotnet-version: |
+            3.1.417
+            6.0.201
+            7.0.203
       - id: builder
         uses: ./.github/workflows/buildtest-action
         with:
@@ -180,11 +201,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-dotnet@v1
+      - name: Setup .NET Core
+        uses: xt0rted/setup-dotnet@v1.0.0
         with:
-          dotnet-version: | 
-            3.1.x
-            6.x.x
+          dotnet-version: |
+            3.1.417
+            6.0.201
+            7.0.203
       - name: Start test service
         run: Start-Process -FilePath "dotnet" -ArgumentList "run --project Docker/MAQSService/MainTestService/MainTestService.csproj"
         shell: pwsh
@@ -207,6 +230,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: xt0rted/setup-dotnet@v1.0.0
+        with:
+          dotnet-version: |
+            3.1.417
+            6.0.201
+            7.0.203
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
@@ -235,6 +265,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: xt0rted/setup-dotnet@v1.0.0
+        with:
+          dotnet-version: |
+            3.1.417
+            6.0.201
+            7.0.203
       - name: Build the docker-compose stack
         run: docker-compose -f Docker/MAQSMongoDB/docker-compose.yml -p CognizantOpenSource/maqs-dotnet up -d
       - id: builder
@@ -257,6 +294,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: xt0rted/setup-dotnet@v1.0.0
+        with:
+          dotnet-version: |
+            3.1.417
+            6.0.201
+            7.0.203
       - name: Build the docker-compose stack
         run: docker-compose -f Docker/MAQSSQLServer/docker-compose.yml -p CognizantOpenSource/maqs-dotnet up -d
       - id: builder
@@ -279,6 +323,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: xt0rted/setup-dotnet@v1.0.0
+        with:
+          dotnet-version: |
+            3.1.417
+            6.0.201
+            7.0.203
       - name: Build the docker-compose stack
         run: docker-compose -f Docker/MAQSEmail/docker-compose.yml -p CognizantOpenSource/maqs-dotnet up -d
       - id: builder
@@ -301,11 +352,12 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: xt0rted/setup-dotnet@v1.0.0
         with:
-          dotnet-version: | 
-            3.1.x
-            6.x.x
+          dotnet-version: |
+            3.1.417
+            6.0.201
+            7.0.203
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
@@ -342,6 +394,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: xt0rted/setup-dotnet@v1.0.0
+        with:
+          dotnet-version: |
+            3.1.417
+            6.0.201
+            7.0.203
       - id: browserupdate
         uses: ./.github/workflows/setuplinbrowser-action
       - id: builder
@@ -363,6 +422,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: xt0rted/setup-dotnet@v1.0.0
+        with:
+          dotnet-version: |
+            3.1.417
+            6.0.201
+            7.0.203
       - id: browserupdate
         uses: ./.github/workflows/setuplinbrowser-action
       - name: Build the docker-compose mongo stack
@@ -388,6 +454,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: xt0rted/setup-dotnet@v1.0.0
+        with:
+          dotnet-version: |
+            3.1.417
+            6.0.201
+            7.0.203
       - id: browserupdate
         uses: ./.github/workflows/setuplinbrowser-action
       - id: builder
@@ -409,6 +482,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: xt0rted/setup-dotnet@v1.0.0
+        with:
+          dotnet-version: |
+            3.1.417
+            6.0.201
+            7.0.203
       - id: browserupdate
         uses: ./.github/workflows/setuplinbrowser-action
       - id: builder
@@ -430,6 +510,13 @@ jobs:
     runs-on: windows-2019
     steps:
       - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: xt0rted/setup-dotnet@v1.0.0
+        with:
+          dotnet-version: |
+            3.1.417
+            6.0.201
+            7.0.203
       - run: dotnet restore Framework/Base.sln
         shell: pwsh
       - run: choco upgrade firefox
@@ -457,6 +544,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: xt0rted/setup-dotnet@v1.0.0
+        with:
+          dotnet-version: |
+            3.1.417
+            6.0.201
+            7.0.203
       - id: browserupdate
         uses: ./.github/workflows/setuplinbrowser-action
       - run: |
@@ -585,9 +679,10 @@ jobs:
       - uses: actions/checkout@v2
       
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v1
+        uses: xt0rted/setup-dotnet@v1.0.0
         with:
-          dotnet-version: 3.1.101
+          dotnet-version: |
+            3.1.417
 
       - name: Install dependencies
         run: dotnet restore Framework/Base.sln
@@ -613,9 +708,10 @@ jobs:
     environment: nuget 
     steps:
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: xt0rted/setup-dotnet@v1.0.0
       with:
-        dotnet-version: 3.1.101
+        dotnet-version: |
+          3.1.417
 
     - uses: actions/download-artifact@v2
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -366,6 +366,7 @@ jobs:
         run: |
             npx playwright install --with-deps
             dotnet build Framework/FrameworkUnitTests/FrameworkUnitTests.csproj -o Framework/FrameworkUnitTests/build
+            pwsh bin\Debug\netX\playwright.ps1 install-deps
             pwsh Framework/FrameworkUnitTests/build/playwright.ps1 install  
       - run: dotnet restore Framework/FrameworkUnitTests/FrameworkUnitTests.csproj
         shell: pwsh

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -366,7 +366,7 @@ jobs:
         run: |
             npx playwright install --with-deps
             dotnet build Framework/FrameworkUnitTests/FrameworkUnitTests.csproj -o Framework/FrameworkUnitTests/build
-            pwsh bin\Debug\netX\playwright.ps1 install-deps
+            pwsh Framework/FrameworkUnitTests/build/playwright.ps1 install-deps
             pwsh Framework/FrameworkUnitTests/build/playwright.ps1 install  
       - run: dotnet restore Framework/FrameworkUnitTests/FrameworkUnitTests.csproj
         shell: pwsh


### PR DESCRIPTION
`actions/setuop-dotnet` has been deprecated.  This PR updates the workflow with a replacement.