### PR TITLE
Remove Framework and Core 3.1

### DIFF
--- a/Framework/AppiumUnitTests/AppiumUnitTests.csproj
+++ b/Framework/AppiumUnitTests/AppiumUnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Framework/BaseAppiumTest/BaseAppiumTest.csproj
+++ b/Framework/BaseAppiumTest/BaseAppiumTest.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFrameworks>net471;netstandard2.0;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 		<PackageId>CognizantSoftvision.Maqs.Appium</PackageId>
 		<Product>CognizantSoftvision.Maqs.Appium</Product>
 		<AssemblyName>CognizantSoftvision.Maqs.BaseAppiumTest</AssemblyName>

--- a/Framework/BaseCompositeTest/BaseCompositeTest.csproj
+++ b/Framework/BaseCompositeTest/BaseCompositeTest.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net471;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <PackageId>CognizantSoftvision.Maqs</PackageId>
     <Product>CognizantSoftvision.Maqs</Product>
     <AssemblyName>CognizantSoftvision.Maqs.BaseCompositeTest</AssemblyName>

--- a/Framework/BaseDatabaseTest/BaseDatabaseTest.csproj
+++ b/Framework/BaseDatabaseTest/BaseDatabaseTest.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFrameworks>net471;netstandard2.0;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 		<PackageId>CognizantSoftvision.Maqs.Database</PackageId>
 		<AssemblyName>CognizantSoftvision.Maqs.BaseDatabaseTest</AssemblyName>
 		<RootNamespace>CognizantSoftvision.Maqs.BaseDatabaseTest</RootNamespace>

--- a/Framework/BaseEmailTest/BaseEmailTest.csproj
+++ b/Framework/BaseEmailTest/BaseEmailTest.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFrameworks>net471;netstandard2.0;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 		<PackageId>CognizantSoftvision.Maqs.Email</PackageId>
 		<AssemblyName>CognizantSoftvision.Maqs.BaseEmailTest</AssemblyName>
 		<RootNamespace>CognizantSoftvision.Maqs.BaseEmailTest</RootNamespace>

--- a/Framework/BaseMongoTest/BaseMongoTest.csproj
+++ b/Framework/BaseMongoTest/BaseMongoTest.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFrameworks>net471;netstandard2.0;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 		<PackageId>CognizantSoftvision.Maqs.Mongo</PackageId>
 		<Product>CognizantSoftvision.Maqs.Mongo</Product>
 		<AssemblyName>CognizantSoftvision.Maqs.BaseMongoTest</AssemblyName>

--- a/Framework/BasePlaywrightTest/BasePlaywrightTest.csproj
+++ b/Framework/BasePlaywrightTest/BasePlaywrightTest.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFrameworks>net471;netstandard2.0;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 		<Nullable>enable</Nullable>
 		<PackageId>CognizantSoftvision.Maqs.Playwright</PackageId>
 		<Product>CognizantSoftvision.Maqs.Playwright</Product>

--- a/Framework/BaseSeleniumTest/BaseSeleniumTest.csproj
+++ b/Framework/BaseSeleniumTest/BaseSeleniumTest.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFrameworks>net471;netstandard2.0;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 		<PackageId>CognizantSoftvision.Maqs.Selenium</PackageId>
 		<Product>CognizantSoftvision.Maqs.Selenium</Product>
 		<AssemblyName>CognizantSoftvision.Maqs.BaseSeleniumTest</AssemblyName>

--- a/Framework/BaseTest/BaseTest.csproj
+++ b/Framework/BaseTest/BaseTest.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFrameworks>net471;netstandard2.0;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 		<PackageId>CognizantSoftvision.Maqs.Base</PackageId>
 		<Product>CognizantSoftvision.Maqs.Base</Product>
 		<AssemblyName>CognizantSoftvision.Maqs.BaseTest</AssemblyName>

--- a/Framework/BaseTestUnitTests/BaseTestUnitTests.csproj
+++ b/Framework/BaseTestUnitTests/BaseTestUnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Framework/BaseWebServiceTest/BaseWebServiceTest.csproj
+++ b/Framework/BaseWebServiceTest/BaseWebServiceTest.csproj
@@ -6,7 +6,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFrameworks>net471;netstandard2.0;netstandard2.1</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
 		<PackageId>CognizantSoftvision.Maqs.WebService</PackageId>
 		<Product>CognizantSoftvision.Maqs.Base</Product>
 		<AssemblyName>CognizantSoftvision.Maqs.BaseWebServiceTest</AssemblyName>

--- a/Framework/CompositeUnitTests/CompositeUnitTests.csproj
+++ b/Framework/CompositeUnitTests/CompositeUnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Framework/DatabaseUnitTests/DatabaseUnitTests.csproj
+++ b/Framework/DatabaseUnitTests/DatabaseUnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Framework/EmailUnitTests/EmailUnitTests.csproj
+++ b/Framework/EmailUnitTests/EmailUnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Framework/FrameworkUnitTests/FrameworkUnitTests.csproj
+++ b/Framework/FrameworkUnitTests/FrameworkUnitTests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<TargetFrameworks>net471;netcoreapp3.1</TargetFrameworks>
+		<TargetFrameworks>net6.0</TargetFrameworks>
 		<ProjectGuid>{D3E59B9F-445E-4484-9B2F-B3FE3ED82CE5}</ProjectGuid>
 		<IsPackable>false</IsPackable>
 		<SonarQubeTestProject>false</SonarQubeTestProject>

--- a/Framework/MongoDBUnitTests/MongoDBUnitTests.csproj
+++ b/Framework/MongoDBUnitTests/MongoDBUnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Framework/PlaywrightTests/PlaywrightTests.csproj
+++ b/Framework/PlaywrightTests/PlaywrightTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/Framework/SeleniumUnitTests/SeleniumUnitTests.csproj
+++ b/Framework/SeleniumUnitTests/SeleniumUnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Framework/SpecFlowExtension/SpecFlowExtension.csproj
+++ b/Framework/SpecFlowExtension/SpecFlowExtension.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net471;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <PackageId>CognizantSoftvision.Maqs.SpecFlow</PackageId>
     <Product>CognizantSoftvision.Maqs.SpecFlow</Product>
     <AssemblyName>CognizantSoftvision.Maqs.SpecFlow</AssemblyName>

--- a/Framework/SpecFlowExtensionNUnitTests/SpecFlowExtensionNUnitTests.csproj
+++ b/Framework/SpecFlowExtensionNUnitTests/SpecFlowExtensionNUnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Framework/SpecFlowExtensionUnitTests/SpecFlowExtensionUnitTests.csproj
+++ b/Framework/SpecFlowExtensionUnitTests/SpecFlowExtensionUnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Framework/Utilities/Utilities.csproj
+++ b/Framework/Utilities/Utilities.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net471;netstandard2.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
     <PackageId>CognizantSoftvision.Maqs.Utilities</PackageId>
     <Product>CognizantSoftvision.Maqs.Utilities</Product>
     <AssemblyName>CognizantSoftvision.Maqs.Utilities</AssemblyName>

--- a/Framework/UtilitiesUnitTests/UtilitiesUnitTests.csproj
+++ b/Framework/UtilitiesUnitTests/UtilitiesUnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 

--- a/Framework/WebServiceUnitTests/WebServiceUnitTests.csproj
+++ b/Framework/WebServiceUnitTests/WebServiceUnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
 


### PR DESCRIPTION
We are removing the support for .Net Framework 4.7.1 and .Net Core 3.1 and upgrading to support 6.0.